### PR TITLE
Remove topic lists for GitHub repos

### DIFF
--- a/src/app/components/GitHubRepos.js
+++ b/src/app/components/GitHubRepos.js
@@ -4,14 +4,6 @@ import Emoji from 'react-emoji-render'
 
 const GitHubRepos = props => {
   const repos = props.repos.map(repo => {
-    const topics = repo.topics.map(topic => {
-      return (
-        <span key={topic} className="topic-tag">
-          {topic}
-        </span>
-      )
-    })
-
     return (
       <li key={repo.id}>
         <a href={repo.html_url} target="_blank">{repo.name}</a>
@@ -19,8 +11,6 @@ const GitHubRepos = props => {
         <span>
           <Emoji text={repo.description} />
         </span>
-        <br />
-        <div className="topics-list">{topics}</div>
       </li>
     )
   })

--- a/src/app/styles/libs/_custom.scss
+++ b/src/app/styles/libs/_custom.scss
@@ -1,14 +1,3 @@
-/* GitHubRepos */
-
-.topic-tag {
-  padding: 8px;
-  color: #a2a2a2;
-  margin: 0px 10px 0px 0px;
-  line-height: 3.5;
-  font-size: 90%;
-  background: #f5f5f5;
-}
-
 /* QiitaItems */
 
 .item-title {


### PR DESCRIPTION
## Description
* Remove topic lists for GitHub repos

Before: 
<img width="1275" alt="screen shot 2018-09-23 at 13 47 11" src="https://user-images.githubusercontent.com/7448569/45953495-363c5480-c045-11e8-8184-053a4021c412.png">

After: 
![Uploading Screen Shot 2018-09-24 at 22.00.43.png…]()
